### PR TITLE
Remove check of owner change on execute()

### DIFF
--- a/src/DssProxy.sol
+++ b/src/DssProxy.sol
@@ -60,7 +60,6 @@ contract DssProxy {
 
     function execute(address target_, bytes memory data_) external auth payable returns (bytes memory response) {
         require(target_ != address(0), "DssProxy/target-address-required");
-        address _owner = owner;
 
         assembly {
             let succeeded := delegatecall(gas(), target_, add(data_, 0x20), mload(data_), 0, 0)
@@ -76,7 +75,5 @@ contract DssProxy {
                 revert(add(response, 0x20), size)
             }
         }
-
-        require(owner == _owner, "DssProxy/owner-can-not-be-changed");
     }
 }


### PR DESCRIPTION
We might want to try and save this additional 2 storage reads (from same slot)
As I understand the reason to have such check might be:
1. To make sure that only the owner (and not the authority) can change the owner (through setOwner).
2. To make sure we have an event emitted on owner change.

However we do not have any similar check that authority hasn't changed during the execution, and malicious authority can do the same harm as malicious owner. So (1) is not that useful (assuming we don't want to check authority as well and add 2 more reads).
Regarding (2), not sure if the event tracking really justifies another read. We did manage without that with the old ds-proxy.

If we do go along with this change than there is still a difference from the old ds-proxy (which used ds-auth), which is that setOwner and setAuthority will only be callable by the owner (and not the authority).
That is probably fine, though might be good to verify with UIs (don't think it should block sending to audit).
